### PR TITLE
Modified fn exists to use next currency id rather than storage contai…

### DIFF
--- a/tokens/src/lib.rs
+++ b/tokens/src/lib.rs
@@ -2044,7 +2044,7 @@ where
 	}
 
 	fn exists(currency_id: Self::CurrencyId) -> bool {
-		TotalIssuance::<T>::contains_key(currency_id)
+		currency_id < <NextCurrencyId<T>>::get()
 	}
 
 	/// either succeeds or leaves state unchanged


### PR DESCRIPTION
…ns_key.

When creating a token with 0 tokens the storage won't get updated, and contains_key on it will result in false. This prevents minting on such a token as, minting calls fn exists on it which used to use contains_key.
fn exists now uses nextTokenId instead.